### PR TITLE
Added default values when generating samples for the first time.

### DIFF
--- a/scripts/format/format.js
+++ b/scripts/format/format.js
@@ -53,6 +53,9 @@ fsp
     sequentialPromises(outputFns, 'Creating Samples', 'samples created').then(
       outputSamples => {
         const appendIndex = getIndexFromOutputSamples(outputSamples);
+        if (!newOutputIndex[format]) {
+          newOutputIndex[format] = {};
+        }
         const outputIndex = Object.keys(appendIndex).reduce(
           (newOutputIndex, format) => {
             const appendingFormatIndex = appendIndex[format];
@@ -72,7 +75,7 @@ fsp
             );
             return newOutputIndex;
           },
-          existingOutputIndex
+          {}
         );
         const condendsedIndex = Object.keys(outputIndex).reduce(
           (byFormat, format) => {


### PR DESCRIPTION
Otherwise it would complain with the following error:

    ```
    Creating Samples ████████████████████████████████████████ 100% | ETA: 0s | 3582/3582 samples created
    (node:313162) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'vsco2-piano-mf' of undefined
        at (...)/samples-alex-bainter/scripts/format/format.js:62:41
        at Array.reduce (<anonymous>)
        at (...)/samples-alex-bainter/scripts/format/format.js:59:72
        at Array.reduce (<anonymous>)
        at (...)/samples-alex-bainter/scripts/format/format.js:56:54
    (Use `node --trace-warnings ...` to show where the warning was created)
    (node:313162) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
    (node:313162) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
    ```